### PR TITLE
Added as simple callback with the filter object so it can be dynamically changed

### DIFF
--- a/ipfilter.go
+++ b/ipfilter.go
@@ -24,6 +24,11 @@ type Config struct {
 
 	// Block by default.
 	BlockByDefault bool
+
+	// called with the newly created filter object to allow for
+	// controlling the filter during runtime.
+	// The underlying filter implementation is thankfully threadsafe
+	CreatedFilter func(*ipfilter.IPFilter)
 }
 
 // DefaultConfig is the default IPFilter middleware config
@@ -55,7 +60,9 @@ func MiddlewareWithConfig(config Config) echo.MiddlewareFunc {
 		BlockByDefault: config.BlockByDefault,
 		Logger:         nil,
 	})
-
+	if config.CreatedFilter != nil {
+		config.CreatedFilter(filter)
+	}
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			if config.Skipper(c) {


### PR DESCRIPTION
Hi,

I noticed that the implementation of the ipfilter middleware, while very useful, lacks the option to dynamically control the filter object. This is a desirable functionality that enables a running service to blacklist a network address based on whatever logic (for example, using some IP blocklist).
I added a simple mechanism for the caller to get hold of the filter object after it is created. Then, the underlying implementation allows for changing it during runtime.

I hope you'll find it useful to add to your implementation.

Cheers,
Shmul